### PR TITLE
Fix #define to correct ENABLE_3AXES build error

### DIFF
--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -25,7 +25,7 @@
 
 #define VERSION 1703               // int or float
 #define BAUD_RATE 57600
-// #define ENABLE_3AXES            // enable/disable 3-axis mode (vs 2-axis)
+// #define ENABLE_3AXES 1           // enable/disable 3-axis mode (vs 2-axis)
 #define ENABLE_LASER_INTERLOCKS    // enable/disable all interlocks
 // #define DRIVEBOARD_USB          // configure IO pins for DriveboardUSB
 // #define STATIC_PWM_FREQ 5000    // only works with LASER_PWM_BIT == 5


### PR DESCRIPTION
Caused a minor compilation error since `ENABLE_3AXES` is used within a C expression, and not just by the preprocessor (this error doesn't come up in the unset case because the line is inside an `#ifdef ENABLE_3AXES` block). 