### PR TITLE
fix arc bug in svg path reader

### DIFF
--- a/backend/jobimport/svg_path_reader.py
+++ b/backend/jobimport/svg_path_reader.py
@@ -377,6 +377,7 @@ class SVGPathReader:
         # plus some recursive sugar for incrementally refining the
         # arc resolution until the requested tolerance is met.
         # http://www.w3.org/TR/SVG/implnote.html#ArcImplementationNotes
+        phi = phi / 360.0 * 2*math.pi
         cp = math.cos(phi)
         sp = math.sin(phi)
         dx = 0.5 * (x1 - x2)


### PR DESCRIPTION
to reproduce, import this file:
https://log2.ch/misc/laser/bug--arc-looks-different-in-inkscape.svg

Cause was found by @cwalther
Seems that Onshape produces such arcs.