### PR TITLE
fix race-condition locking up the firmware after instant-stop

### DIFF
--- a/firmware/src/planner.c
+++ b/firmware/src/planner.c
@@ -249,8 +249,7 @@ inline void planner_discard_current_block() {
 }
 
 inline void planner_reset_block_buffer() {
-  block_buffer_head = 0;
-  block_buffer_tail = 0;
+  block_buffer_tail = block_buffer_head;
 }
 
 


### PR DESCRIPTION
When all block buffers are in use, some waiting loops store (block_buffer_head+1)
before the loop starts, under the assumption that no other code can add a block
to the buffer. Which is kind of correct. But if an instant-stop did happen during
such a loop it got stuck there forever.