### PR TITLE
added support for Debian 9 official BB images

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -128,6 +128,13 @@ if sys.platform == "linux2":
         import RPi.GPIO
         conf['hardware'] = 'raspberrypi'
     except ImportError:
+        # try to import Adafruit GPIO library for Debian 9 based official BB image
+        try:
+            global GPIO
+            import Adafruit_BBIO.GPIO as GPIO
+        except ImportError:
+            # Adafruit GPIO library unavailable. Do nothing and continue.
+            pass
         # os.uname() on BBB:
         # ('Linux', 'lasersaur', '3.8.13-bone20',
         #  '#1 SMP Wed May 29 06:14:59 UTC 2013', 'armv7l')
@@ -180,24 +187,28 @@ elif conf['hardware'] == 'beaglebone':
     for pin46 in pin46list:
         os.system("echo gpio > %s" % (pin46))
 
-    try:
-        fw = file("/sys/class/gpio/export", "w")
-        fw.write("%d" % (71))
+    if ('GPIO' in globals()):
+        GPIO.setup("P8_46", GPIO.OUT)
+        GPIO.output("P8_46", GPIO.HIGH)
+    else:
+        try:
+            fw = file("/sys/class/gpio/export", "w")
+            fw.write("%d" % (71))
+            fw.close()
+        except IOError:
+            # probably already exported
+            pass
+        # set the gpio pin to output
+        # echo out > /sys/class/gpio/gpio71/direction
+        fw = file("/sys/class/gpio/gpio71/direction", "w")
+        fw.write("out")
         fw.close()
-    except IOError:
-        # probably already exported
-        pass
-    # set the gpio pin to output
-    # echo out > /sys/class/gpio/gpio71/direction
-    fw = file("/sys/class/gpio/gpio71/direction", "w")
-    fw.write("out")
-    fw.close()
-    # set the gpio pin high
-    # echo 1 > /sys/class/gpio/gpio71/value
-    fw = file("/sys/class/gpio/gpio71/value", "w")
-    fw.write("1")
-    fw.flush()
-    fw.close()
+        # set the gpio pin high
+        # echo 1 > /sys/class/gpio/gpio71/value
+        fw = file("/sys/class/gpio/gpio71/value", "w")
+        fw.write("1")
+        fw.flush()
+        fw.close()
 
     ### Set up atmega328 reset control - BeagleBone Black
     # The reset pin is connected to GPIO2_9 (2*32+9 = 73).
@@ -209,24 +220,28 @@ elif conf['hardware'] == 'beaglebone':
     for pin44 in pin44list:
         os.system("echo gpio > %s" % (pin44))
 
-    try:
-        fw = file("/sys/class/gpio/export", "w")
-        fw.write("%d" % (73))
+    if ('GPIO' in globals()):
+        GPIO.setup("P8_44", GPIO.OUT)
+        GPIO.output("P8_44", GPIO.HIGH)
+    else:
+        try:
+            fw = file("/sys/class/gpio/export", "w")
+            fw.write("%d" % (73))
+            fw.close()
+        except IOError:
+            # probably already exported
+            pass
+        # set the gpio pin to output
+        # echo out > /sys/class/gpio/gpio73/direction
+        fw = file("/sys/class/gpio/gpio73/direction", "w")
+        fw.write("out")
         fw.close()
-    except IOError:
-        # probably already exported
-        pass
-    # set the gpio pin to output
-    # echo out > /sys/class/gpio/gpio73/direction
-    fw = file("/sys/class/gpio/gpio73/direction", "w")
-    fw.write("out")
-    fw.close()
-    # set the gpio pin high
-    # echo 1 > /sys/class/gpio/gpio73/value
-    fw = file("/sys/class/gpio/gpio73/value", "w")
-    fw.write("1")
-    fw.flush()
-    fw.close()
+        # set the gpio pin high
+        # echo 1 > /sys/class/gpio/gpio73/value
+        fw = file("/sys/class/gpio/gpio73/value", "w")
+        fw.write("1")
+        fw.flush()
+        fw.close()
 
     ### read stepper driver configure pin GPIO2_12 (2*32+12 = 76).
     # Low means Geckos, high means SMC11s
@@ -236,22 +251,26 @@ elif conf['hardware'] == 'beaglebone':
     for pin39 in pin39list:
         os.system("echo gpio > %s" % (pin39))
 
-    try:
-        fw = file("/sys/class/gpio/export", "w")
-        fw.write("%d" % (76))
+    if ('GPIO' in globals()):
+        GPIO.setup("P8_39", GPIO.IN)
+        ret = GPIO.input("P8_39")
+    else:
+        try:
+            fw = file("/sys/class/gpio/export", "w")
+            fw.write("%d" % (76))
+            fw.close()
+        except IOError:
+            # probably already exported
+            pass
+        # set the gpio pin to input
+        fw = file("/sys/class/gpio/gpio76/direction", "w")
+        fw.write("in")
         fw.close()
-    except IOError:
-        # probably already exported
-        pass
-    # set the gpio pin to input
-    fw = file("/sys/class/gpio/gpio76/direction", "w")
-    fw.write("in")
-    fw.close()
-    # set the gpio pin high
-    fw = file("/sys/class/gpio/gpio76/value", "r")
-    ret = fw.read()
-    fw.close()
-    # print "Stepper driver configure pin is: " + str(ret)
+        # set the gpio pin high
+        fw = file("/sys/class/gpio/gpio76/value", "r")
+        ret = fw.read()
+        fw.close()
+        # print "Stepper driver configure pin is: " + str(ret)
 
 elif conf['hardware'] == 'raspberrypi':
     if not conf['firmware']:

--- a/backend/flash.py
+++ b/backend/flash.py
@@ -86,39 +86,49 @@ def flash_upload(serial_port=conf['serial_port'], resources_dir=conf['rootdir'],
             # Setting it to low triggers a reset.
             # echo 71 > /sys/class/gpio/export
             try:
-                fw = file("/sys/class/gpio/export", "w")
-                fw.write("%d" % (71))
+                import Adafruit_BBIO.GPIO as GPIO
+                GPIO.setup("P8_46", GPIO.OUT)
+                GPIO.output("P8_46", GPIO.LOW)
+                GPIO.setup("P8_44", GPIO.OUT)
+                GPIO.output("P8_44", GPIO.LOW)
+                time.sleep(0.5)
+                GPIO.output("P8_46", GPIO.HIGH)
+                GPIO.output("P8_44", GPIO.HIGH)
+            except ImportError:
+                try:
+                    fw = file("/sys/class/gpio/export", "w")
+                    fw.write("%d" % (71))
+                    fw.close()
+                    fwb = file("/sys/class/gpio/export", "w")
+                    fwb.write("%d" % (73))
+                    fwb.close()
+                except IOError:
+                    # probably already exported
+                    pass
+                # set the gpio pin to output
+                # echo out > /sys/class/gpio/gpio71/direction
+                fw = file("/sys/class/gpio/gpio71/direction", "w")
+                fw.write("out")
                 fw.close()
-                fwb = file("/sys/class/gpio/export", "w")
-                fwb.write("%d" % (73))
+                fwb = file("/sys/class/gpio/gpio73/direction", "w")
+                fwb.write("out")
                 fwb.close()
-            except IOError:
-                # probably already exported
-                pass
-            # set the gpio pin to output
-            # echo out > /sys/class/gpio/gpio71/direction
-            fw = file("/sys/class/gpio/gpio71/direction", "w")
-            fw.write("out")
-            fw.close()
-            fwb = file("/sys/class/gpio/gpio73/direction", "w")
-            fwb.write("out")
-            fwb.close()
-            # set the gpio pin low -> high
-            # echo 1 > /sys/class/gpio/gpio71/value
-            fw = file("/sys/class/gpio/gpio71/value", "w")
-            fw.write("0")
-            fw.flush()
-            fwb = file("/sys/class/gpio/gpio73/value", "w")
-            fwb.write("0")
-            fwb.flush()
-            time.sleep(0.5)
-            fw.write("1")
-            fw.flush()
-            fw.close()
-            fwb.write("1")
-            fwb.flush()
-            fwb.close()
-            time.sleep(0.1)
+                # set the gpio pin low -> high
+                # echo 1 > /sys/class/gpio/gpio71/value
+                fw = file("/sys/class/gpio/gpio71/value", "w")
+                fw.write("0")
+                fw.flush()
+                fwb = file("/sys/class/gpio/gpio73/value", "w")
+                fwb.write("0")
+                fwb.flush()
+                time.sleep(0.5)
+                fw.write("1")
+                fw.flush()
+                fw.close()
+                fwb.write("1")
+                fwb.flush()
+                fwb.close()
+                time.sleep(0.1)
         elif conf['hardware'] == 'raspberrypi':
             print "Flashing from Raspberry Pi ..."
             import thread
@@ -148,33 +158,43 @@ def reset_atmega():
     print "Resetting Atmega ..."
     if conf['hardware'] == 'beaglebone':
         try:
-            fw = file("/sys/class/gpio/export", "w")
-            fw.write("%d" % (71))
+            import Adafruit_BBIO.GPIO as GPIO
+            GPIO.setup("P8_46", GPIO.OUT)
+            GPIO.output("P8_46", GPIO.LOW)
+            GPIO.setup("P8_44", GPIO.OUT)
+            GPIO.output("P8_44", GPIO.LOW)
+            time.sleep(0.2)
+            GPIO.output("P8_46", GPIO.HIGH)
+            GPIO.output("P8_44", GPIO.HIGH)
+        except ImportError:
+            try:
+                fw = file("/sys/class/gpio/export", "w")
+                fw.write("%d" % (71))
+                fw.close()
+                fwb = file("/sys/class/gpio/export", "w")
+                fwb.write("%d" % (73))
+                fwb.close()
+            except IOError:
+                pass
+            fw = file("/sys/class/gpio/gpio71/direction", "w")
+            fw.write("out")
             fw.close()
-            fwb = file("/sys/class/gpio/export", "w")
-            fwb.write("%d" % (73))
+            fwb = file("/sys/class/gpio/gpio73/direction", "w")
+            fwb.write("out")
             fwb.close()
-        except IOError:
-            pass
-        fw = file("/sys/class/gpio/gpio71/direction", "w")
-        fw.write("out")
-        fw.close()
-        fwb = file("/sys/class/gpio/gpio73/direction", "w")
-        fwb.write("out")
-        fwb.close()
-        fw = file("/sys/class/gpio/gpio71/value", "w")
-        fw.write("0")
-        fw.flush()
-        fwb = file("/sys/class/gpio/gpio73/value", "w")
-        fwb.write("0")
-        fwb.flush()
-        time.sleep(0.2)
-        fw.write("1")
-        fw.flush()
-        fw.close()
-        fwb.write("1")
-        fwb.flush()
-        fwb.close()
+            fw = file("/sys/class/gpio/gpio71/value", "w")
+            fw.write("0")
+            fw.flush()
+            fwb = file("/sys/class/gpio/gpio73/value", "w")
+            fwb.write("0")
+            fwb.flush()
+            time.sleep(0.2)
+            fw.write("1")
+            fw.flush()
+            fw.close()
+            fwb.write("1")
+            fwb.flush()
+            fwb.close()
     elif conf['hardware'] == 'raspberrypi':
         import RPi.GPIO as GPIO
         GPIO.setmode(GPIO.BCM)  # use chip pin number

--- a/scripts/driveboardapp.service
+++ b/scripts/driveboardapp.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Lasersaur driveboardapp
+After=network.target
+
+[Service]
+Type=simple
+Restart=always
+ExecStart=/usr/bin/python /root/driveboardapp/backend/app.py
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Official BB images ( beagleboard.org images )
-------------------------------------

More recent Beagle Board [official image](https://beagleboard.org/latest-images) with linux kernel 4 provide improved networking stability and updated wifi divers with better support for usb dongles.
This branch make use of [Adafruit BeagleBone-IO-Python library](https://learn.adafruit.com/setting-up-io-python-library-on-beaglebone-black/overview) for dealing with GPIO.
It was tested with Debian 9.5 2018-10-07 4GB SD IoT image and is backward compatible with the Lasersaur BBB Image v15.01

To try this branch:

- get [latest Beagle Board official image](https://beagleboard.org/latest-images)
- Clone to a micro sd-card with [this](https://beagleboard.org/getting-started) or [this](http://help.ubuntu.com/community/Installation/FromImgFiles) instructions
- Boot BBB from this card. Be sure you plugged an ethernet cable to be able to ssh into it.
    - The BBB should automatically boot from the sd-card if inserted. (If not, hold S2 button when connecting power until the four blue LEDs illuminate.)
- ssh to BBB: `ssh debian@beaglebone.local`
    - default password is: `temppwd`
- optionally Install disk image to EMMC:
    - ssh to BBB and edit /boot/uEnv.txt (require sudo). Uncomment the line:`#cmdline=init=/opt/scripts/tools/eMMC/init-eMMC-flasher-v3.sh`
    - reboot and the eMMC flashing will take place. Allow few minutes untill all four leds will turn on and back off again.
    - don't forget to remove the sd card before rebooting or the eMMC flashing will restart
- ssh to BBB and change the hostname from beaglebone to lasersaur
    - edit /etc/hostname (require sudo). Change `beaglebone` to `lasersaur`
    - edit /etc/hosts (require sudo). Replace `beaglebone` to `lasersaur` anywhere in the file. Save and reboot
- setup root account ( Adafruit GPIO library doesn't work with sudo )
    - ssh as usual and set root password: `sudo passwd root`. Enter a new root password
    - `su -` to switch to root user
    - enable ssh root access editing /etc/ssh/sshd_config Add a line in the Authentication section of the file that says `PermitRootLogin yes`. This line may already exist and be commented out with a "#". In this case, remove the "#" and eventually change `prohibit-password` to `yes`
    - restart ssh server: `systemctl restart ssh.service`
- configure the BB image for use with driveboardapp:
    - ssh to BBB: `ssh root@lasersaur.local`
    - configure wifi:
        - plug your wifi usb dongle and verify it's being recognized running `dmesg`, last lines should list some info on the newly inserted device. If not you can try to add drivers following [this guide](https://deeplyembedded.org/wifi-beaglebone/)
        - run `connmanctl`
        - at the connmanctl prompt enter `enable wifi`
        - now enter `scan wifi` and after `services`, take note of the string next to your wifi SSID
        - at the connmanctl prompt enter `agent on` and then `connect wifi_78abbb9bd6ac_56696e617931393930_managed_psk` replacing the long string with what you got for your wifi
        - when requested enter your passphrase. After a while you will be connected to your wifi
        - you can set a static IP with the connmanctl command: `config wifi_78abbb9bd6ac_56696e617931393930_managed_psk --ipv4 manual 192.168.1.123 255.255.255.0 192.168.1.1 --nameservers 8.8.8.8` replacing parameters for your needs
    - disable HDMI to avoid wifi issues and enable UART1. Edit /boot/uEnv.txt and uncomment the lines:`#disable_uboot_overlay_video=1` and `#disable_uboot_overlay_audio=1`
    - edit and change the line `#uboot_overlay_addr4=/lib/firmware/<file4>.dtbo` to `uboot_overlay_addr4=/lib/firmware/BB-UART1-00A0.dtbo`
   - disable BB builtin web server
        - `systemctl disable bonescript.service`              
        - `systemctl disable bonescript.socket`
        - `systemctl disable bonescript-autorun.service`
- reboot and install driveboardapp and dependencies
    - install python-imaging: `apt-get update && apt-get install python-imaging`
    - install avrdude: `apt-get install avrdude`
    - clone this repo: `git clone https://github.com/luky83/driveboardapp.git`
    - `cd driveboardapp`
    - checkout debian9.5 branch : `git checkout debian9.5`
    - run `python backend/app.py`
    - END

### Run driveboardapp as systemd service at boot:
- `cp /root/driveboardapp/scripts/driveboardapp.service /etc/systemd/system/`
- `systemctl daemon-reload`
- `systemctl enable driveboardapp.service`
- `systemctl start driveboardapp.service`

### Install Adafruits wifi reset
- `cd ~`
- `apt-get update && apt-get install ntpdate`
- `ntpdate -b -s -u pool.ntp.org`
- git clone https://github.com/adafruit/wifi-reset.git
- cd wifi-reset
- chmod +x install.sh
- ./install.sh

### Optional upgrade everything
- `apt-get update`
- `apt-get dist-upgrade`
- `cd /opt/scripts/tools/`
- `git pull`
- `./update_kernel.sh`
- `reboot`